### PR TITLE
use built schema's canonical URI rather than hardcoded one

### DIFF
--- a/src/encrypt/mod.rs
+++ b/src/encrypt/mod.rs
@@ -34,7 +34,7 @@ fn validate(req: EncryptReq) -> Result<ValidPlainConfig, Error> {
     let index = builder.into_index();
 
     let mut validator = Validator::<'_, Annotation, FullContext>::new(&index);
-    validator.prepare(&schema_url)?;
+    validator.prepare(&built_schema.curi)?;
     // Deserialization cannot fail.
     ::json::de::walk(&config.0, &mut validator).unwrap();
 

--- a/src/encrypt/test.rs
+++ b/src/encrypt/test.rs
@@ -14,6 +14,7 @@ fn sops_args() -> crate::SopsArgs {
 }
 
 const SCHEMA: &str = r#"{
+    "$id": "https://example/schema/under/test",
     "type": "object",
     "properties": {
         "not_secret": {"type": "string"},


### PR DESCRIPTION
The schema may have an `$id` keyword which changes the canonical URI.